### PR TITLE
Render cursors initial version

### DIFF
--- a/src/App.global.less
+++ b/src/App.global.less
@@ -16,7 +16,7 @@
 @table-alt-background-color: #f0f2ef;
 @markdown-border-color: #ddd;
 @markdown-code-background-color: #fdefef;
-@user-1: #fb9f89;
+@user-1: @primary;
 
 body {
   height: 100vh;
@@ -58,7 +58,7 @@ body {
 
 .user-marker-1 {
   position: absolute;
-  width: 1px !important;
+  width: 2px !important;
   background-color: @user-1;
 }
 
@@ -67,9 +67,9 @@ body {
   position: absolute;
   left: -2px;
   top: -2px;
-  width: 5px;
-  height: 5px;
-  background-color: @base-color;
+  width: 6px;
+  height: 6px;
+  background-color: @user-1;
 }
 
 /**

--- a/src/components/CodeCell.tsx
+++ b/src/components/CodeCell.tsx
@@ -78,17 +78,9 @@ const CodeCell: React.FC<{
     (newValue: string) => {
       if (!isEditable) return;
 
-      const cursor_pos = editorRef.current?.editor.getCursorPosition();
-
-      const changes: Partial<DCell> = {
+      onChange(cell_id, {
         contents: newValue,
-      };
-
-      if (cursor_pos !== undefined) {
-        changes.cursor_pos = editorRef.current?.editor.session.getDocument().positionToIndex(cursor_pos);
-      }
-
-      onChange(cell_id, changes);
+      });
     },
     [cell_id, isEditable, onChange]
   );
@@ -97,17 +89,9 @@ const CodeCell: React.FC<{
     (selection: { cursor: { row: number; column: number } }) => {
       if (!isEditable) return;
 
-      const contents = editorRef.current?.editor.getValue();
-
-      const changes: Partial<DCell> = {
+      onChange(cell_id, {
         cursor_pos: editorRef.current?.editor.session.getDocument().positionToIndex(selection.cursor),
-      };
-
-      if (contents !== undefined) {
-        changes.contents = contents;
-      }
-
-      onChange(cell_id, changes);
+      });
     },
     [cell_id, isEditable, onChange]
   );

--- a/src/components/NotebookCell.tsx
+++ b/src/components/NotebookCell.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { StyleSheet, css } from 'aphrodite';
 import { Icon } from 'rsuite';
+import { DCell } from '@actually-colab/editor-types';
 
 import { ReduxState } from '../types/redux';
 import { _editor } from '../redux/actions';
@@ -65,7 +66,7 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   codeContainerLockedByOtherUser: {
-    opacity: 0.5,
+    opacity: 0.7,
   },
   cellToolbar: {
     display: 'flex',
@@ -202,11 +203,9 @@ const NotebookCell: React.FC<{ cell: ImmutableEditorCell }> = ({ cell }) => {
   }, [cell, dispatch]);
 
   const onChange = React.useCallback(
-    (cell_id: string, newValue: string) => {
+    (cell_id: string, changes: Partial<DCell>) => {
       dispatchEditCell(cell_id, {
-        changes: {
-          contents: newValue,
-        },
+        changes,
       });
     },
     [dispatchEditCell]

--- a/src/redux/middleware/ReduxEditorClient.ts
+++ b/src/redux/middleware/ReduxEditorClient.ts
@@ -338,8 +338,19 @@ const ReduxEditorClient = (): Middleware<Record<string, unknown>, ReduxState, an
           break;
         }
 
+        const cell = store.getState().editor.cells.get(action.cell_id);
+        if (cell === undefined) {
+          console.error('Cell was undefined');
+          break;
+        }
+
         if (action.changes !== undefined) {
-          socketClient?.editCell(notebook.nb_id, action.cell_id, action.changes);
+          socketClient?.editCell(notebook.nb_id, action.cell_id, {
+            language: cell.language,
+            contents: cell.contents,
+            cursor_pos: cell.cursor_pos,
+            ...action.changes,
+          });
         }
         break;
       }


### PR DESCRIPTION
Closes #6 
Closes #246 

Known issues:
- cursors can get out of sync if you add new code because the index overshoots. Instead should use row/column. #252 